### PR TITLE
Fix documentation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Kaur.Mixfile do
      build_embedded: Mix.env == :prod,
      deps: deps(),
      description: "A bunch of helper functions to ease the development of your applications",
-     docs: [main: "README", extras: ["README.md"]],
+     docs: [main: "readme", extras: ["README.md"]],
      elixir: "~> 1.2",
      homepage_url: @project_url,
      name: "Kaur",


### PR DESCRIPTION
Redirection on Hex documentation is broken because it redirects to `README.html` instead of `readme.html`

That change should fix it. At least it works on my laptop