### PR TITLE
Add `tap` to `Kaur` & `Kaur.Result`

### DIFF
--- a/lib/kaur.ex
+++ b/lib/kaur.ex
@@ -1,0 +1,20 @@
+defmodule Kaur do
+  @moduledoc """
+  Generic utilities working with any kind of data.
+  """
+
+  @doc ~S"""
+  Calls the next function but discards the result. It always returns the original value.
+
+  ## Examples
+
+    iex> business_logic = fn x -> x * 2 end
+    ...> Kaur.tap(42, business_logic)
+    42
+  """
+  def tap(value, function) do
+    function.(value)
+
+    value
+  end
+end

--- a/lib/kaur/environment.ex
+++ b/lib/kaur/environment.ex
@@ -3,13 +3,13 @@ defmodule Kaur.Environment do
   Utilities for working with configuration allowing environment variables.
 
   * `{:system, something}`: will load the environment variable stored in `something`
-  * `value`: will returns the value
+  * `value`: will return the value
   """
 
   alias Kaur.Result
 
-  @doc """
-  Read the value or environment variable for the `key` in `application`'s environment
+  @doc ~S"""
+  Reads the value or environment variable for the `key` in `application`'s environment.
 
   ### Examples
 
@@ -36,8 +36,8 @@ defmodule Kaur.Environment do
     |> Result.and_then(&load_environment_variable/1)
   end
 
-  @doc """
-  Read the value or environment variable for the `key` in `application`'s environment
+  @doc ~S"""
+  Reads the value or environment variable for the `key` in `application`'s environment.
 
   ### Examples
 

--- a/lib/kaur/secure.ex
+++ b/lib/kaur/secure.ex
@@ -1,10 +1,10 @@
 defmodule Kaur.Secure do
   @moduledoc """
-  Utilities to generate secure API Keys
+  Utilities to generate secure API Keys.
   """
 
-  @doc """
-  Generate a formatted String of length 24, using base 64 encoding.
+  @doc ~S"""
+  Generates a formatted String of length 24, using base 64 encoding.
 
   ## Examples
 

--- a/test/kaur/result_test.exs
+++ b/test/kaur/result_test.exs
@@ -1,5 +1,39 @@
 defmodule Kaur.ResultTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureIO
+
   doctest Kaur.Result
+
+  test "tap: calls the function and returns original data" do
+    original = Kaur.Result.ok("World")
+
+    assert "Hello World\n" == capture_io(fn ->
+      assert original == Kaur.Result.tap(original, fn name -> IO.puts "Hello #{name}" end)
+    end)
+  end
+
+  test "tap: does not call the function and returns original data" do
+    original = Kaur.Result.error("Oops")
+
+    assert "" == capture_io(fn ->
+      assert original == Kaur.Result.tap(original, fn name -> IO.puts "Hello #{name}" end)
+    end)
+  end
+
+  test "tap_error: does not call the function and returns original data" do
+    original = Kaur.Result.ok("World")
+
+    assert "" == capture_io(fn ->
+      assert original == Kaur.Result.tap_error(original, fn name -> IO.puts "Hello #{name}" end)
+    end)
+  end
+
+  test "tap_error: does call the function and returns original data" do
+    original = Kaur.Result.error("Oops")
+
+    assert "Hello Oops\n" == capture_io(fn ->
+      assert original == Kaur.Result.tap_error(original, fn name -> IO.puts "Hello #{name}" end)
+    end)
+  end
 end

--- a/test/kaur_test.exs
+++ b/test/kaur_test.exs
@@ -1,0 +1,11 @@
+defmodule KaurTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  test "tap: call the function and returns original data" do
+    assert "Hello World\n" == capture_io(fn ->
+      assert "World" == Kaur.tap("World", fn name -> IO.puts "Hello #{name}" end)
+    end)
+  end
+end


### PR DESCRIPTION
* Add `Kaur.tap/1` to call a function with a value and discard the result
* Add `Kaur.Result.tap/1` to call a function with a value when value is an ok tuple and discard the result
* Add `Kaur.Result.tap_error/1` to call a function with a value when value is an error tuple and discard the result
* Fix documentation to use `~S` sigils which allow variable interpolation in doctests
* Update documentation to be more consistent