### PR TITLE
Prepare version 2.0.0 of Kaur

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ iex> MyModule.rent_a_car %Person{name: "Jane", age: 42, bonus: 0.9}
 {:ok, "Welcome Jane, you can rent a car"}
 
 iex> MyModule.rent_a_car %Person{name: "John", age: 42, bonus: 0.5}
-{:error, Sorry John, but you need a bonus of 0.8 but have only 0.5."}
+{:error, "Sorry John, but you need a bonus of 0.8 but have only 0.5."}
 
 iex> MyModule.rent_a_car %Person{name: "Robert", age: 11, bonus: 0.9}
 {:error, "Sorry Robert, but you need to be older than 21"}

--- a/lib/kaur/environment.ex
+++ b/lib/kaur/environment.ex
@@ -1,6 +1,6 @@
 defmodule Kaur.Environment do
   @moduledoc """
-  **This module is deprecated and will be no longer maintained**
+  **This module is deprecated and will no longer be maintained**
 
   Utilities for working with configuration allowing environment variables.
 
@@ -30,7 +30,7 @@ defmodule Kaur.Environment do
       iex> Kaur.Environment.read(:my_app, :something_else)
       {:error, :no_value}
   """
-  @deprecated "Kaur.Environment is deprecated and will be no longer maintained"
+  @deprecated "Kaur.Environment is deprecated and will no longer be maintained"
   @spec read(:atom, :atom) :: Result.t(any, any)
   def read(application, key) do
     application
@@ -59,7 +59,7 @@ defmodule Kaur.Environment do
       iex> Kaur.Environment.read(:my_app, :something_else)
       {:error, :no_value}
   """
-  @deprecated "Kaur.Environment is deprecated and will be no longer maintained"
+  @deprecated "Kaur.Environment is deprecated and will no longer be maintained"
   @spec read(:atom, :atom, [:atom]) :: Result.t(any, any)
   def read(application, key, sub_keys) do
     application

--- a/lib/kaur/environment.ex
+++ b/lib/kaur/environment.ex
@@ -1,5 +1,7 @@
 defmodule Kaur.Environment do
   @moduledoc """
+  **This module is deprecated and will be no longer maintained**
+
   Utilities for working with configuration allowing environment variables.
 
   * `{:system, something}`: will load the environment variable stored in `something`
@@ -28,6 +30,7 @@ defmodule Kaur.Environment do
       iex> Kaur.Environment.read(:my_app, :something_else)
       {:error, :no_value}
   """
+  @deprecated "Kaur.Environment is deprecated and will be no longer maintained"
   @spec read(:atom, :atom) :: Result.t(any, any)
   def read(application, key) do
     application
@@ -56,6 +59,7 @@ defmodule Kaur.Environment do
       iex> Kaur.Environment.read(:my_app, :something_else)
       {:error, :no_value}
   """
+  @deprecated "Kaur.Environment is deprecated and will be no longer maintained"
   @spec read(:atom, :atom, [:atom]) :: Result.t(any, any)
   def read(application, key, sub_keys) do
     application

--- a/lib/kaur/secure.ex
+++ b/lib/kaur/secure.ex
@@ -1,6 +1,6 @@
 defmodule Kaur.Secure do
   @moduledoc """
-  **This module is deprecated and will be no longer maintained**
+  **This module is deprecated and will no longer be maintained**
 
   Utilities to generate secure API Keys.
   """
@@ -13,7 +13,7 @@ defmodule Kaur.Secure do
     iex> Kaur.Secure.generate_api_key()
     "tEhdf77Pr8BDjRc9JMKGzQ=="
   """
-  @deprecated "Kaur.Secure is deprecated and will be no longer maintained"
+  @deprecated "Kaur.Secure is deprecated and will no longer be maintained"
   @spec generate_api_key :: String.t()
   def generate_api_key do
     Base.url_encode64(random_bytes())

--- a/lib/kaur/secure.ex
+++ b/lib/kaur/secure.ex
@@ -1,5 +1,7 @@
 defmodule Kaur.Secure do
   @moduledoc """
+  **This module is deprecated and will be no longer maintained**
+
   Utilities to generate secure API Keys.
   """
 
@@ -11,6 +13,7 @@ defmodule Kaur.Secure do
     iex> Kaur.Secure.generate_api_key()
     "tEhdf77Pr8BDjRc9JMKGzQ=="
   """
+  @deprecated "Kaur.Secure is deprecated and will be no longer maintained"
   @spec generate_api_key :: String.t()
   def generate_api_key do
     Base.url_encode64(random_bytes())

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Kaur.Mixfile do
       package: package(),
       source_url: @project_url,
       start_permanent: Mix.env() == :prod,
-      version: "1.1.0",
+      version: "2.0.0",
       dialyzer: dialyzer()
     ]
   end


### PR DESCRIPTION
This PR is a first step aimed at introducing the new architecture for Kaur. 
It depreciates `Kaur.Secure` and `Kaur.Environment` and it changes the version from `1.1.0` to `2.0.0` (since `Kaur.Result` is now well typed).